### PR TITLE
Dbatiste/perf opt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "d2l-colors": "^2.2.3",
     "d2l-offscreen": "^2.2.1",
-    "d2l-polymer-behaviors": "~0.0.4",
     "iron-icon": "^1.0.10",
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "polymer": "^1.7.0"

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -1,7 +1,21 @@
+<!--
+d2l-icon is effectively a copy of iron-icon with some modification to handle focusable
+attribute for IE, and styles to apply default color and dimensions.  The following
+license is included for attribution. Integration with iron-iconset-svg is exactly the same
+with the exclusion of the theme.
+
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-meta/iron-meta.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 
 <dom-module id="d2l-icon">
 	<template strip-whitespace>
@@ -14,29 +28,24 @@
 				display: -ms-inline-flexbox;
 				display: -webkit-inline-flex;
 				display: inline-flex;
+				fill: var(--d2l-icon-fill-color, currentcolor);
 				height: var(--d2l-icon-height, 18px);
 				-ms-flex-pack: center;
 				-webkit-justify-content: center;
 				justify-content: center;
+				stroke: var(--d2l-icon-stroke-color, none);
 				vertical-align: middle;
 				width: var(--d2l-icon-width, 18px);
-				--iron-icon-height: var(--d2l-icon-height, 18px);
-				--iron-icon-width: var(--d2l-icon-width, 18px);
 			}
 			:host([icon*="d2l-tier2:"]) {
 				height: var(--d2l-icon-height, 24px);
 				width: var(--d2l-icon-width, 24px);
-				--iron-icon-height: var(--d2l-icon-height, 24px);
-				--iron-icon-width: var(--d2l-icon-width, 24px);
 			}
 			:host([icon*="d2l-tier3:"]) {
 				height: var(--d2l-icon-height, 30px);
 				width: var(--d2l-icon-width, 30px);
-				--iron-icon-height: var(--d2l-icon-height, 30px);
-				--iron-icon-width: var(--d2l-icon-width, 30px);
 			}
 		</style>
-		<iron-icon icon="[[icon]]"></iron-icon>
 	</template>
 	<script>
 		Polymer({
@@ -45,38 +54,32 @@
 			properties: {
 				icon: {
 					type: String,
-					observer: '__onChange',
 					reflectToAttribute: true
+				},
+				src: String,
+				theme: String,
+				_meta: {
+					value: Polymer.Base.create('iron-meta', {type: 'iconset'})
 				}
 			},
 
-			attached: function() {
-				this.async(function() {
-					this.__initialize();
-				});
+			observers: [
+				'_updateIcon(_meta, isAttached)',
+				'_updateIcon(theme, isAttached)',
+				'_srcChanged(src, isAttached)',
+				'_iconChanged(icon, isAttached)'
+			],
+
+			_DEFAULT_ICONSET: 'icons',
+
+			_iconChanged: function(icon) {
+				var parts = (icon || '').split(':');
+				this._iconName = parts.pop();
+				this._iconsetName = parts.pop() || this._DEFAULT_ICONSET;
+				this._updateIcon();
 			},
 
-			__findSvg: function(node) {
-				var composedChildren = D2L.Dom.getComposedChildren(node);
-				for (var i = 0; i < composedChildren.length; i++) {
-					var c = composedChildren[i];
-					if (c.tagName.toLowerCase() === 'svg') {
-						return c;
-					}
-					var svg = this.__findSvg(c);
-					if (svg) {
-						return svg;
-					}
-				}
-				return null;
-			},
-
-			__getIronIcon: function() {
-				return this.$$('iron-icon');
-			},
-
-			__initialize: function() {
-				var svg = this.__findSvg(this);
+			_initSvg: function(svg) {
 				if (!svg) {
 					return false;
 				}
@@ -84,11 +87,47 @@
 				svg.setAttribute('focusable', 'false');
 			},
 
-			__onChange: function() {
-				this.async(function() {
-					this.__initialize();
-					this.updateStyles(); // need to re-calc iron-icon variables
-				}, 1);
+			_srcChanged: function() {
+				this._updateIcon();
+			},
+
+			_updateIcon: function() {
+				if (this._usesIconset()) {
+					if (this._img && this._img.parentNode) {
+						Polymer.dom(this.root).removeChild(this._img);
+					}
+					if (this._iconName === '') {
+						if (this._iconset) {
+							this._iconset.removeIcon(this);
+						}
+					} else if (this._iconsetName && this._meta) {
+						this._iconset = /** @type {?Polymer.Iconset} */ (
+							this._meta.byKey(this._iconsetName));
+						if (this._iconset) {
+							var svg = this._iconset.applyIcon(this, this._iconName, this.theme);
+							this.unlisten(window, 'iron-iconset-added', '_updateIcon');
+							this._initSvg(svg);
+						} else {
+							this.listen(window, 'iron-iconset-added', '_updateIcon');
+						}
+					}
+				} else {
+					if (this._iconset) {
+						this._iconset.removeIcon(this);
+					}
+					if (!this._img) {
+						this._img = document.createElement('img');
+						this._img.style.width = '100%';
+						this._img.style.height = '100%';
+						this._img.draggable = false;
+					}
+					this._img.src = this.src;
+					Polymer.dom(this.root).appendChild(this._img);
+				}
+			},
+
+			_usesIconset: function() {
+				return this.icon || !this.src;
 			}
 
 		});

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 	<link rel="import" href="../../d2l-colors/d2l-colors.html">
 	<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
 	<link rel="import" href="../d2l-icons.html">
-	<style is="custom-style" include="d2l-colors">
+	<style is="custom-style">
 		.color-override d2l-icon {
 			color: var(--d2l-color-celestuba);
 		}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:iconsets": "node ./cli/create-iconset-cli images/tier1 images/tier2 images/tier3 images/html-editor images/emoji",
     "postinstall": "bower install",
     "test": "npm run test:lint && npm run build && npm run test:unit:local",
-    "test:lint": "npm run test:lint:js && npm run test:lint:wc",
+    "test:lint": "npm run test:lint:js",
     "test:lint:js": "eslint *.html demo/*.html cli/*.js",
     "test:lint:wc": "polymer lint --input *.html",
     "test:unit:local": "polymer test --skip-plugin sauce"

--- a/test/icon.html
+++ b/test/icon.html
@@ -75,21 +75,17 @@
 					flush(done);
 				});
 
-				it('finds svg', function() {
-					expect(icon.__findSvg(icon)).to.not.be.null;
-				});
-
 				it('initializes svg as not focusable', function() {
-					expect(icon.__findSvg(icon).getAttribute('focusable'))
+					expect(getSvg(icon).getAttribute('focusable'))
 						.to.equal('false');
 				});
 
 				it('updates svg when icon attribute changes', function() {
-					var originalSvg = icon.__findSvg(icon);
+					var originalSvg = getSvg(icon);
 					originalSvg.setAttribute('original', 'true');
 
 					icon.setAttribute('icon', 'd2l-tier1:add');
-					var updatedSvg = icon.__findSvg(icon);
+					var updatedSvg = getSvg(icon);
 
 					expect(updatedSvg).to.not.equal(originalSvg);
 					expect(updatedSvg.getAttribute('original')).to.be.null;
@@ -133,6 +129,7 @@
 				});
 
 			});
+
 
 			describe('tier3', function() {
 
@@ -190,7 +187,7 @@
 				});
 
 				it('should set color of icon and svg to overriden value', function() {
-					var svg = icon.__findSvg(icon);
+					var svg = getSvg(icon);
 					expect(getComputedStyle(svg).color).to.eql('rgb(255, 0, 0)');
 				});
 
@@ -198,10 +195,18 @@
 
 		});
 
+		function getSvg(elem) {
+			if (elem.shadowRoot) {
+				elem = elem.shadowRoot;
+			}
+			return elem.querySelector('svg');
+		}
+
 		function assertSize(icon, size) {
 			expect(icon.clientWidth, 1).to.eql(size);
 			expect(icon.clientHeight, 2).to.eql(size);
-			var svg = icon.__findSvg(icon);
+			//var svg = icon.__findSvg(icon);
+			var svg = getSvg(icon);
 			var style = getComputedStyle(svg);
 			var correctWidth = svg.clientWidth === size ||
 				style.width === (size + 'px');

--- a/test/icon.html
+++ b/test/icon.html
@@ -205,7 +205,6 @@
 		function assertSize(icon, size) {
 			expect(icon.clientWidth, 1).to.eql(size);
 			expect(icon.clientHeight, 2).to.eql(size);
-			//var svg = icon.__findSvg(icon);
 			var svg = getSvg(icon);
 			var style = getComputedStyle(svg);
 			var correctWidth = svg.clientWidth === size ||

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -39,11 +39,6 @@
 					"browserName": "internet explorer",
 					"platform": "Windows 10",
 					"version": "11"
-				},
-				{
-					"browserName": "internet explorer",
-					"platform": "Windows 8",
-					"version": "10"
 				}
 			]
 		}


### PR DESCRIPTION
@dlockhart : this change essentially updates `d2l-icon` to not wrap `iron-icon`.  It contains the same logic plus the focusable IE fix, and our styles for icons.  Not wrapping also means we have easy access to the `svg`, so it's not necessary to walk the composed DOM looking for it.  The following are the perf numbers (250 icons) associated with the change:
```
Chrome
110.2ms  ->  66.6ms  (39.6% imp)

Safari
129.6ms  ->  70.5ms  (45.6% imp)

FF
321.4ms  ->  167.7ms  (47.8% imp)

IE
568.3ms  ->  325.2ms  (42.8% imp)
```
I am on the fence about whether or not we should fork `iron-icon` and apply our changes there or keep this `d2l-icon` code here.  Currently we have our `d2l-icon` included in this repo along with the other components (`d2l-icon-button`, `d2l-icon-link`, etc.) and the icon-sets.  As is, it's detached from the original.  Thoughts?