### PR TITLE
switching order of inclusion of d2l-demo-template around

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,8 @@
 <head>
 	<title>d2l-icons</title>
 	<script src="https://s.brightspace.com/lib/webcomponentsjs/0.7.21/webcomponents.min.js"></script>
-	<link rel="import" href="../../d2l-colors/d2l-colors.html">
 	<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
+	<link rel="import" href="../../d2l-colors/d2l-colors.html">
 	<link rel="import" href="../d2l-icons.html">
 	<style is="custom-style">
 		.color-override d2l-icon {


### PR DESCRIPTION
Looks like because demo-template blows away the `Polymer` object in the first line, it can't be included _after_ Polymer.

We should probably fix this in the latest version of the demo-template.