### PR TITLE
fixes #146: no longer need to set focusable

### DIFF
--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -96,14 +96,6 @@ Polymer-based web component for icons
 				this._updateIcon();
 			},
 
-			_initSvg: function(svg) {
-				if (!svg) {
-					return false;
-				}
-				/* IE prevent svg from being focusable */
-				svg.setAttribute('focusable', 'false');
-			},
-
 			_srcChanged: function() {
 				this._updateIcon();
 			},
@@ -121,9 +113,8 @@ Polymer-based web component for icons
 						this._iconset = /** @type {?Polymer.Iconset} */ (
 							this._meta.byKey(this._iconsetName));
 						if (this._iconset) {
-							var svg = this._iconset.applyIcon(this, this._iconName, this.theme);
+							this._iconset.applyIcon(this, this._iconName, this.theme);
 							this.unlisten(window, 'iron-iconset-added', '_updateIcon');
-							this._initSvg(svg);
 						} else {
 							this.listen(window, 'iron-iconset-added', '_updateIcon');
 						}


### PR DESCRIPTION
Latest `iron-iconset-svg` does this for us now:
https://github.com/PolymerElements/iron-iconset-svg/blob/master/iron-iconset-svg.html#L254