### PR TITLE
Add CSS rule for [hidden]

### DIFF
--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -52,6 +52,10 @@ Polymer-based web component for icons
 				height: var(--d2l-icon-height, 30px);
 				width: var(--d2l-icon-width, 30px);
 			}
+			/* required since display of inline-block is non-default */
+			:host([hidden]) {
+				display: none;
+			}
 		</style>
 	</template>
 	<script>


### PR DESCRIPTION
Effectively the same change as https://github.com/BrightspaceUI/loading-spinner/pull/26, applying the `hidden` attribute to a `d2l-icon` won't actually hide it, turns out. This is because the `display: none` part of `hidden` ends up getting overridden by the `:host { display }` rule defined within `d2l-icon`.