### PR TITLE
Reduce calls to "_updateIcon"

### DIFF
--- a/d2l-icon.js
+++ b/d2l-icon.js
@@ -86,8 +86,6 @@ Polymer({
 		 */
 		src: String,
 
-		theme: String,
-
 		_meta: {
 			value: Base.create('iron-meta', {type: 'iconset'})
 		}
@@ -96,21 +94,23 @@ Polymer({
 
 	observers: [
 		'_updateIcon(_meta, isAttached)',
-		'_updateIcon(theme, isAttached)',
 		'_srcChanged(src, isAttached)',
 		'_iconChanged(icon, isAttached)'
 	],
 
 	_DEFAULT_ICONSET: 'icons',
 
-	_iconChanged: function(icon) {
+	_iconChanged: function(icon, attached) {
+		if (!attached) return;
 		var parts = (icon || '').split(':');
 		var iconName = parts.pop();
-		if (iconName !== this._iconName) {
-			this._d2lIconName = undefined;
+		var iconSetName = parts.pop() || this._DEFAULT_ICONSET;
+		if (iconName === this._iconName && iconSetName === this._iconsetName && attached === this.attached) {
+			return;
 		}
+		this._d2lIconName = undefined;
 		this._iconName = iconName;
-		this._iconsetName = parts.pop() || this._DEFAULT_ICONSET;
+		this._iconsetName = iconSetName;
 		this._updateIcon();
 	},
 
@@ -135,7 +135,7 @@ Polymer({
 						this._d2lIconName = this._iconset.querySelector(`#d2l-icon-${this._iconName}`) ?
 							(`d2l-icon-${this._iconName}`) : this._iconName;
 					}
-					this._iconset.applyIcon(this, this._d2lIconName, this.theme);
+					this._iconset.applyIcon(this, this._d2lIconName);
 					this.unlisten(window, 'iron-iconset-added', '_updateIcon');
 				} else {
 					this.listen(window, 'iron-iconset-added', '_updateIcon');


### PR DESCRIPTION
This change reduces the number of calls to `_updateIcon` during init from 5 to 1:
- We're not using `theme` at all and iconset's [applyIcon doesn't even use it](https://github.com/PolymerElements/iron-iconset-svg/blob/master/iron-iconset-svg.js#L123) anyway, so we can remove its listener, reducing calls by 1
- The `_iconChanged` listener gets called twice with `attached` equal to `undefined`. If nothing's been attached yet, I'm assuming we can just wait and do nothing. This reduces calls by a further 2.
- Lastly, we can compare the incoming changed values into `_iconChanged` against their existing values, and only call `_updateIcon` if something has actually changed.

Performance results (classlist, 100 per page, local dev instance):

Browser | Before | After|%
------------ | -------------| -------------| -------------
Chrome| 1930|1782|8%
Safari|1605|1573|2%
Firefox|2172|2075|4%
Edge|8474|7911|7%
IE11|9200|8700|5%