### PR TITLE
Add automatic CI versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,20 @@ script:
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:polymer:local || travis_terminate 1;
   fi
+- |
+  if [ "$TRAVIS_BRANCH" == "master" ] && [ $TRAVIS_PULL_REQUEST == false ]; then
+    echo "Not a Pull Request and on branch master so bumping version";
+    frauci-update-version;
+    export TRAVIS_TAG=$(frauci-get-version)
+  fi
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
+  - REPO_NAME=icons
   - SAUCE_USERNAME: Desire2Learn
   - secure: NOor8Yc6J+8QC/JudZ3aN8MmCyV7/HqkriUnNDrb3fCzgWQEqI5slGnkOveEP1rNdbUKySxS/kgZFWKiUPOaBofpa+URZmCzbUtYebbvNYDfj9R3v0kQEV+kMsAsEoUkn0biw8S2rpFkcAdZZZEbkkPyUpZVrgtLhaTbuDt6B9Y=
+  - secure: nLUyzTFXAl4QIh6bdAGqqJiKzjiz7yvjnHkFEuTg4/BKc9a3u8T7SvMmu5IlnW2RugmOaMdPHO0jMVmTbsVpiP57/jBv0vjytdwr1BQro8pn9YwVBxn9eHQZ0NV7cdF8RKpncg/jRKFut/wMtRk3W3NzR+eC9Hw6jl2EvGtclq4=

--- a/README.md
+++ b/README.md
@@ -303,3 +303,12 @@ To learn more about how best to determine if an icon should be mirrored, refer t
 [bower-image]: https://badge.fury.io/bo/d2l-icons.svg
 [ci-url]: https://travis-ci.org/BrightspaceUI/icons
 [ci-image]: https://travis-ci.org/BrightspaceUI/icons.svg?branch=master
+
+## Versioning
+
+Commits and PR merges to master will automatically do a minor version bump which will:
+* Update the version in `package.json`
+* Add a tag matching the new version
+* Create a github release matching the new version
+
+By using either **[increment major]** or **[increment patch]** notation inside your merge message, you can overwrite the default version upgrade of minor to the position of your choice.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "xml2js": "^0.4.16",
     "yargs": "^4.1.0"
   },
-  "version": "6.0.7",
+  "version": "6.0.8",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.1",
     "eslint-plugin-html": "^4.0.1",
+    "frau-ci": "^1.33.2",
     "fs": "0.0.2",
     "imagemin": "^4.0.0",
     "images-to-variables": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "xml2js": "^0.4.16",
     "yargs": "^4.1.0"
   },
-  "version": "6.0.8",
+  "version": "6.0.9",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "xml2js": "^0.4.16",
     "yargs": "^4.1.0"
   },
-  "version": "",
+  "version": "6.0.7",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Updates travis.yml to use frauci-update-version to bump package.json version and tag commit on each commit/pr merge to master. Use travis releases provider to create a new github release matching tag.