### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vinyl-fs": "^2.3.1",
     "yargs": "^4.1.0"
   },
-  "version": "6.8.1",
+  "version": "6.8.2",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Trying a manual release of this repo (I'll make a GH tag/release manually in the UI after this merges) so that repos pointing at it using a GitHub reference will pick up the fact that `frau-ci` is no longer a `devDependency`. It was removed from NPM after all the references to it were cleaned up.